### PR TITLE
Install and setup Credo, also run it to verify proper installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,59 @@
 version: 2.1
 
 jobs:
+  getdeps:
+    docker:
+      - image: "cimg/elixir:1.13.3"
+    steps:
+      - checkout
+      - restore_cache:
+          key: v2-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+      - run: mix local.hex --force
+      - run: mix deps.get
+      - save_cache:
+          key: v2-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths: "deps"
+      - persist_to_workspace:
+          paths:
+          - project
+          - .mix
+          - .hex
+          root: ~/
   build:
     docker:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
-      - run: mix local.hex --force
-      - run: mix deps.get
-      - run: mix run
+      - attach_workspace:
+          at: ~/
+      - run: mix compile
   test:
     docker:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
-      - run: mix local.hex --force
-      - run: mix deps.get
+      - attach_workspace:
+          at: ~/
       - run: mix test
   credo:
     docker:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
-      - run: mix local.hex --force
-      - run: mix deps.get
+      - attach_workspace:
+          at: ~/
       - run: mix credo
 
 workflows:
   build_and_test:
     jobs:
-      - credo
-      - build
-      - test
+      - getdeps
+      - credo:
+          requires:
+            - getdeps
+      - build:
+          requires:
+            - getdeps
+      - test:
+          requires:
+            - getdeps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,5 @@ workflows:
   build_and_test:
     jobs:
       - credo
-      - build:
-          requires:
-            - credo
-      - test:
-          requires:
-            - credo
-            - build
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,34 @@ jobs:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
+      - run: mix local.hex --force
+      - run: mix deps.get
       - run: mix run
   test:
     docker:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
+      - run: mix local.hex --force
+      - run: mix deps.get
       - run: mix test
+  credo:
+    docker:
+      - image: "cimg/elixir:1.13.3"
+    steps:
+      - checkout
+      - run: mix local.hex --force
+      - run: mix deps.get
+      - run: mix credo
 
 workflows:
   build_and_test:
     jobs:
-      - build
+      - credo
+      - build:
+          requires:
+            - credo
       - test:
           requires:
+            - credo
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,29 @@
 version: 2.1
 
 jobs:
-  getdeps:
+  build:
     docker:
       - image: "cimg/elixir:1.13.3"
     steps:
       - checkout
+      - run: mix local.hex --force
       - restore_cache:
           key: v2-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-      - run: mix local.hex --force
-      - run: mix deps.get
+      - restore_cache:
+          key: v2-build-cache-{{ .Branch }}
+      - run: mix do deps.get, compile
       - save_cache:
           key: v2-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
+      - save_cache:
+          key: v2-build-cache-{{ .Branch }}
+          paths: "_build"
       - persist_to_workspace:
           paths:
           - project
           - .mix
           - .hex
           root: ~/
-  build:
-    docker:
-      - image: "cimg/elixir:1.13.3"
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/
-      - run: mix compile
   test:
     docker:
       - image: "cimg/elixir:1.13.3"
@@ -47,13 +44,10 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - getdeps
+      - build
       - credo:
           requires:
-            - getdeps
-      - build:
-          requires:
-            - getdeps
+            - build
       - test:
           requires:
-            - getdeps
+            - build

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 A Tic-Tac-Toe walking skeleton
 
 ## Prerequisites/Requirements
-- Install [HomeBrew](https://docs.brew.sh/Installation)
-- Install [Elixir](https://elixir-lang.org/install.html#macos)
+1. Install [HomeBrew](https://docs.brew.sh/Installation)
+2. Install [Elixir](https://elixir-lang.org/install.html#macos)
+3. Run the `mix deps.get` command
 
 ## Command to run application
 - mix start

--- a/lib/command_line.ex
+++ b/lib/command_line.ex
@@ -1,4 +1,7 @@
 defmodule CommandLine do
+  @moduledoc """
+  Documentation for `CommandLine`.
+  """
   def display(message) do
     IO.write(message)
   end

--- a/lib/mix/tasks/start.ex
+++ b/lib/mix/tasks/start.ex
@@ -1,5 +1,8 @@
 defmodule Mix.Tasks.Start do
   use Mix.Task
+  @moduledoc """
+  Documentation for `MixTasksStart`.
+  """
 
   def run(_) do
     TicTacToe.welcome_message()

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,8 @@ defmodule TicTacToe.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    []
+    [
+      {:credo, "~> 1.6", only: [:dev, :test], runtime: false}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.6.4", "ddd474afb6e8c240313f3a7b0d025cc3213f0d171879429bf8535d7021d9ad78", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "c28f910b61e1ff829bffa056ef7293a8db50e87f2c57a9b5c3f57eee124536b7"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
+}


### PR DESCRIPTION
Update README and mix.exs to reflect new Credo dependency.
Update circle ci config file to include a run of credo.
Update start.ex and command_line.ex to follow Credo suggestions.