### PR TITLE
Board determines if there is a tie, if so displays prompt and exits

### DIFF
--- a/lib/board.ex
+++ b/lib/board.ex
@@ -5,7 +5,7 @@ defmodule Board do
 
   @spec setup_initial_board(non_neg_integer()) :: map()
   def setup_initial_board(board_dimensions \\ 3) do
-    Map.new(1..board_dimensions * board_dimensions, fn position -> {position, "#{position}"} end)
+    Map.new(1..board_dimensions * board_dimensions, fn position -> {position, :empty} end)
   end
 
   @spec place_a_symbol(map(), String.t(), String.t()) :: map()
@@ -13,9 +13,23 @@ defmodule Board do
     Map.replace(board, String.to_integer(player_move), symbol)
   end
 
+  @spec game_status(map()) :: atom()
+  def game_status(board) do
+    cond do
+      has_player_won?(board) -> :won
+      is_board_full?(board) -> :tied
+      true -> :in_progress
+    end
+  end
+
   @spec has_player_won?(map()) :: boolean()
-  def has_player_won?(board) do
+  defp has_player_won?(board) do
     Enum.any?([get_all_rows_status(board), get_all_columns_status(board), get_both_diagonals_status(board)])
+  end
+
+  @spec is_board_full?(map) :: boolean
+  defp is_board_full?(board) do
+    !Enum.member?(Map.values(board), :empty)
   end
 
   @spec get_board_dimensions(map()) :: integer()
@@ -30,7 +44,7 @@ defmodule Board do
     |> Map.values()
     |> Enum.chunk_every(board_dimensions)
     |> Enum.map(&Enum.uniq/1)
-    |> Enum.any?(fn win -> Enum.count(win) == 1 end)
+    |> Enum.any?(&is_winning_vector?/1)
   end
 
   @spec get_all_columns_status(map()) :: boolean()
@@ -41,7 +55,7 @@ defmodule Board do
     |> Enum.chunk_every(board_dimensions)
     |> Enum.zip()
     |> Enum.map(fn columns -> Enum.uniq(Tuple.to_list(columns)) end)
-    |> Enum.any?(fn win -> Enum.count(win) == 1 end)
+    |> Enum.any?(&is_winning_vector?/1)
   end
 
   @spec get_both_diagonals_status(map()) :: boolean()
@@ -52,7 +66,7 @@ defmodule Board do
     |> Enum.chunk_every(board_dimensions)
     |> get_diagonal_values(board_dimensions)
     |> Enum.map(&Enum.uniq/1)
-    |> Enum.any?(fn win -> Enum.count(win) == 1 end)
+    |> Enum.any?(&is_winning_vector?/1)
   end
 
   @spec get_diagonal_values(list(), integer()) :: list()
@@ -60,5 +74,10 @@ defmodule Board do
     forward_diagonal = for diagonal_index <- 0..board_dimensions - 1, do: Enum.at(Enum.at(board, diagonal_index), diagonal_index)
     backward_diagonal = for diagonal_index <- 0..board_dimensions - 1, do: Enum.at(Enum.at(board, diagonal_index), (board_dimensions - 1) - diagonal_index)
     [forward_diagonal, backward_diagonal]
+  end
+
+  @spec is_winning_vector?(list()) :: boolean()
+  defp is_winning_vector?(symbols_in_vector) do
+    Enum.count(symbols_in_vector) == 1 && !Enum.member?(symbols_in_vector, :empty)
   end
 end

--- a/lib/command_line_formatter.ex
+++ b/lib/command_line_formatter.ex
@@ -7,6 +7,8 @@ defmodule CommandLineFormatter do
   def format_board(board) do
     board_dimensions = Board.get_board_dimensions(board)
     board
+    |> Enum.map(&format_position/1)
+    |> Map.new()
     |> Map.values()
     |> Enum.chunk_every(board_dimensions)
     |> Enum.map_intersperse(build_separator(board_dimensions), &build_row/1)
@@ -14,6 +16,12 @@ defmodule CommandLineFormatter do
     |> List.insert_at(-1, "\n\n")
     |> Enum.join()
   end
+
+  defp format_position({board_position, :empty}) do
+    {board_position, "#{board_position}"}
+  end
+
+  defp format_position(position), do: position
 
   @spec build_row(List.t()) :: String.t()
   defp build_row(row) do

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -14,8 +14,21 @@ defmodule TicTacToe do
     board = Board.place_a_symbol(board, player_move, "X")
     communicator.display(communicator_formatter.format_board(board))
 
-    if Board.has_player_won?(board) do
-      communicator.display("Player X has Won!\n")
+    board
+    |> get_game_status_message()
+    |> communicator.display()
+  end
+
+  @spec get_game_status_message(map()) :: String.t()
+  defp get_game_status_message(board) do
+    game_status = Board.game_status(board)
+    cond do
+      game_status == :won ->
+        "Player X has Won!\n"
+      game_status == :tied ->
+        "No player has won, tie!\n"
+      true ->
+        ""
     end
   end
 end

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -4,34 +4,34 @@ defmodule BoardTest do
   describe "setup_initial_board/1" do
     test "populates initial board with defaulted dimensions of 3, board length of 9" do
       assert Board.setup_initial_board() == %{
-        1 => "1", 2 => "2", 3 => "3",
-        4 => "4", 5 => "5", 6 => "6",
-        7 => "7", 8 => "8", 9 => "9"
+        1 => :empty, 2 => :empty, 3 => :empty,
+        4 => :empty, 5 => :empty, 6 => :empty,
+        7 => :empty, 8 => :empty, 9 => :empty
       }
     end
 
     test "populates initial board with dimensions of 2, board length of 4" do
       assert Board.setup_initial_board(2) == %{
-        1 => "1", 2 => "2",
-        3 => "3", 4 => "4"
+        1 => :empty, 2 => :empty,
+        3 => :empty, 4 => :empty
       }
     end
   end
 
   describe "place_a_symbol/3" do
-    test "replaces the 2 with an X" do
+    test "replaces the :empty with an X" do
       board = %{
-        1 => "1", 2 => "2", 3 => "3",
-        4 => "4", 5 => "5", 6 => "6",
-        7 => "7", 8 => "8", 9 => "9"
+        1 => :empty, 2 => :empty, 3 => :empty,
+        4 => :empty, 5 => :empty, 6 => :empty,
+        7 => :empty, 8 => :empty, 9 => :empty
       }
 
       board = Board.place_a_symbol(board, "2", "X")
 
       expected_board = %{
-        1 => "1", 2 => "X", 3 => "3",
-        4 => "4", 5 => "5", 6 => "6",
-        7 => "7", 8 => "8", 9 => "9"
+        1 => :empty, 2 => "X", 3 => :empty,
+        4 => :empty, 5 => :empty, 6 => :empty,
+        7 => :empty, 8 => :empty, 9 => :empty
       }
 
       assert board == expected_board
@@ -41,67 +41,87 @@ defmodule BoardTest do
   describe "get_board_dimensions/1" do
     test "gets the dimensions of the board given a board of length 9" do
       board = %{
-        1 => "1", 2 => "2", 3 => "3",
-        4 => "4", 5 => "5", 6 => "6",
-        7 => "7", 8 => "8", 9 => "9"
+        1 => :empty, 2 => :empty, 3 => :empty,
+        4 => :empty, 5 => :empty, 6 => :empty,
+        7 => :empty, 8 => :empty, 9 => :empty
       }
 
       board_dimensions = Board.get_board_dimensions(board)
 
-      assert board_dimensions === 3
+      assert board_dimensions == 3
     end
 
     test "gets the dimensions of the board given a board of length 4" do
       board = %{
-        1 => "1", 2 => "2",
-        3 => "3", 4 => "4"
+        1 => :empty, 2 => :empty,
+        3 => :empty, 4 => :empty
       }
 
       board_dimensions = Board.get_board_dimensions(board)
 
-      assert board_dimensions === 2
+      assert board_dimensions == 2
     end
   end
 
-  describe "has_player_won?/1" do
-    test "determines noone has won" do
+  describe "game_status/1" do
+    test "determines game has not been won or tied" do
       board = %{
-        1 => "X", 2 => "2", 3 => "X",
-        4 => "O", 5 => "5", 6 => "O",
-        7 => "X", 8 => "8", 9 => "O"
+        1 => "X", 2 => :empty, 3 => "X",
+        4 => "O", 5 => :empty, 6 => "O",
+        7 => "X", 8 => :empty, 9 => "O"
       }
 
-      assert Board.has_player_won?(board) === false
+      assert Board.game_status(board) == :in_progress
     end
 
     test "determines X is the winner in the diagonal direction" do
       board = %{
-        1 => "X", 2 => "2", 3 => "X",
+        1 => "X", 2 => :empty, 3 => "X",
         4 => "O", 5 => "X", 6 => "O",
-        7 => "X", 8 => "8", 9 => "O"
+        7 => "X", 8 => :empty, 9 => "O"
       }
 
-      assert Board.has_player_won?(board) === true
+      assert Board.game_status(board) == :won
     end
 
     test "determines X is the winner in the 3rd column" do
       board = %{
-        1 => "X", 2 => "2", 3 => "X",
-        4 => "O", 5 => "5", 6 => "X",
-        7 => "X", 8 => "8", 9 => "X"
+        1 => "X", 2 => :empty, 3 => "X",
+        4 => "O", 5 => :empty, 6 => "X",
+        7 => "X", 8 => :empty, 9 => "X"
       }
 
-      assert Board.has_player_won?(board) === true
+      assert Board.game_status(board) == :won
     end
 
     test "determines X is the winner in the 3rd row" do
       board = %{
-        1 => "X", 2 => "2", 3 => "X",
-        4 => "O", 5 => "5", 6 => "O",
+        1 => "X", 2 => :empty, 3 => "X",
+        4 => "O", 5 => :empty, 6 => "O",
         7 => "X", 8 => "X", 9 => "X"
       }
 
-      assert Board.has_player_won?(board) === true
+      assert Board.game_status(board) == :won
+    end
+
+    test "determines there is a winner even with a full board" do
+      board = %{
+        1 => "X", 2 => "X", 3 => "X",
+        4 => "O", 5 => "O", 6 => "X",
+        7 => "X", 8 => "O", 9 => "O"
+      }
+
+      assert Board.game_status(board) == :won
+    end
+
+    test "determines there is a tie" do
+      board = %{
+        1 => "X", 2 => "O", 3 => "O",
+        4 => "O", 5 => "X", 6 => "X",
+        7 => "X", 8 => "O", 9 => "O"
+      }
+
+      assert Board.game_status(board) == :tied
     end
   end
 end

--- a/test/command_line_formatter_test.exs
+++ b/test/command_line_formatter_test.exs
@@ -4,9 +4,9 @@ defmodule CommandLineFormatterTest do
   describe "format_board/1" do
     test "converts the board into a CommandLine display friendly format" do
       board = %{
-        1 => "1", 2 => "2", 3 => "3",
-        4 => "4", 5 => "5", 6 => "6",
-        7 => "7", 8 => "8", 9 => "9"
+        1 => :empty, 2 => :empty, 3 => :empty,
+        4 => :empty, 5 => :empty, 6 => :empty,
+        7 => :empty, 8 => :empty, 9 => :empty
       }
 
       assert CommandLineFormatter.format_board(board) ===

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -48,15 +48,30 @@ defmodule TicTacToeTest do
       start_supervised!(CommunicatorMock)
 
       board = %{
-        1 => "1", 2 => "X", 3 => "X",
-        4 => "O", 5 => "5", 6 => "O",
-        7 => "X", 8 => "8", 9 => "O"
+        1 => :empty, 2 => "X", 3 => "X",
+        4 => "O", 5 => :empty, 6 => "O",
+        7 => "X", 8 => :empty, 9 => "O"
       }
 
       TicTacToe.start(CommunicatorMock, CommandLineFormatter, board)
 
       assert :sys.get_state(CommunicatorMockServer) =~
         "Player X has Won!"
+    end
+
+    test "(unit test) displays tie message" do
+      start_supervised!(CommunicatorMock)
+
+      board = %{
+        1 => :empty, 2 => "O", 3 => "X",
+        4 => "O", 5 => "O", 6 => "X",
+        7 => "X", 8 => "X", 9 => "O"
+      }
+
+      TicTacToe.start(CommunicatorMock, CommandLineFormatter, board)
+
+      assert :sys.get_state(CommunicatorMockServer) =~
+        "No player has won, tie!"
     end
   end
 end


### PR DESCRIPTION
Change the non-occupied board spaces to :empty instead of their
numeral position. Still displays empty spaces as their numeral
positions.