### PR TITLE
Move any module related to the games communication into own directory

### DIFF
--- a/lib/communication/command_line/command_line_communicator.ex
+++ b/lib/communication/command_line/command_line_communicator.ex
@@ -1,8 +1,9 @@
-defmodule CommandLine do
+defmodule Communication.CommandLine.CommandLineCommunicator do
   @moduledoc """
   The module that handles displaying a message to the Command Line
   """
 
+  alias Communication.CommunicationBehaviour
   @behaviour CommunicationBehaviour
 
   def display(message) do

--- a/lib/communication/command_line/command_line_formatter.ex
+++ b/lib/communication/command_line/command_line_formatter.ex
@@ -1,4 +1,4 @@
-defmodule CommandLineFormatter do
+defmodule Communication.CommandLine.CommandLineFormatter do
   @moduledoc """
   The module that handles formatting a board to be displayed to the Command Line
   """

--- a/lib/communication/communication_behaviour.ex
+++ b/lib/communication/communication_behaviour.ex
@@ -1,4 +1,4 @@
-defmodule CommunicationBehaviour do
+defmodule Communication.CommunicationBehaviour do
   @moduledoc """
   The module that defines a generic display function
   """

--- a/lib/mix/tasks/start.ex
+++ b/lib/mix/tasks/start.ex
@@ -4,7 +4,10 @@ defmodule Mix.Tasks.Start do
   Documentation for `MixTasksStart`.
   """
 
+  alias Communication.CommandLine.CommandLineFormatter
+  alias Communication.CommandLine.CommandLineCommunicator
+
   def run(_) do
-    TicTacToe.start(CommandLine, CommandLineFormatter)
+    TicTacToe.start(CommandLineCommunicator, CommandLineFormatter)
   end
 end

--- a/test/communication/command_line/command_line_communicator_test.exs
+++ b/test/communication/command_line/command_line_communicator_test.exs
@@ -1,18 +1,20 @@
-defmodule CommandLineTest do
+defmodule CommandLineCommunicatorTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
+
+  alias Communication.CommandLine.CommandLineCommunicator
 
   describe "display/1" do
     test "displays message" do
       message = "foo"
-      assert capture_io(fn -> CommandLine.display(message) end) === message
+      assert capture_io(fn -> CommandLineCommunicator.display(message) end) === message
     end
   end
 
   describe "read_input/0" do
     test "reads message" do
       user_input_message = "1"
-      assert capture_io(user_input_message, fn -> IO.write(CommandLine.read_input()) end) ===
+      assert capture_io(user_input_message, fn -> IO.write(CommandLineCommunicator.read_input()) end) ===
         "Please input desired placement: #{user_input_message}"
     end
   end

--- a/test/communication/command_line/command_line_formatter_test.exs
+++ b/test/communication/command_line/command_line_formatter_test.exs
@@ -1,6 +1,8 @@
 defmodule CommandLineFormatterTest do
   use ExUnit.Case
 
+  alias Communication.CommandLine.CommandLineFormatter
+
   describe "format_board/1" do
     test "converts the board into a CommandLine display friendly format" do
       board = %{

--- a/test/end_to_end_tests/tic_tac_toe_test.exs
+++ b/test/end_to_end_tests/tic_tac_toe_test.exs
@@ -2,11 +2,14 @@ defmodule TicTacToeEndToEndTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
 
+  alias Communication.CommandLine.CommandLineFormatter
+  alias Communication.CommandLine.CommandLineCommunicator
+
   describe "start/1" do
     test "displays the starting board and the end board with a winning message for X given corresponding inputs" do
       user_input = [input: "1\n2\n3\n4\n5\n6\n7\n"]
 
-      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter)) end)
+      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter)) end)
 
       assert game_play =~
         """
@@ -34,7 +37,7 @@ defmodule TicTacToeEndToEndTest do
     test "displays the end board with a winning message for O given a fresh start and corresponding inputs" do
       user_input = [input: "1\n2\n3\n5\n6\n8\n"]
 
-      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter)) end)
+      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter)) end)
 
       assert game_play =~
         """
@@ -62,7 +65,7 @@ defmodule TicTacToeEndToEndTest do
     test "displays the end board with a tied message given a fresh start and corresponding inputs" do
       user_input = [input: "1\n2\n3\n4\n6\n5\n7\n9\n8\n"]
 
-      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter)) end)
+      game_play = capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter)) end)
 
       assert game_play =~
         """

--- a/test/integration_tests/tic_tac_toe_test.exs
+++ b/test/integration_tests/tic_tac_toe_test.exs
@@ -2,6 +2,9 @@ defmodule TicTacToeIntegrationTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
 
+  alias Communication.CommandLine.CommandLineFormatter
+  alias Communication.CommandLine.CommandLineCommunicator
+
   describe "start/1" do
     test "displays welcome message and board when first called" do
       user_input = "1"
@@ -12,7 +15,7 @@ defmodule TicTacToeIntegrationTest do
         7 => :empty, 8 => :empty, 9 => :empty
       }
 
-      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter, board)) end) =~
+      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter, board)) end) =~
         """
         Welcome to Tic-Tac-Toe
 
@@ -33,7 +36,7 @@ defmodule TicTacToeIntegrationTest do
         7 => :empty, 8 => "X", 9 => :empty
       }
 
-      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter, board)) end) =~
+      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter, board)) end) =~
         """
         1 | X | X
         --|---|--
@@ -52,7 +55,7 @@ defmodule TicTacToeIntegrationTest do
         7 => :empty, 8 => "O", 9 => :empty
       }
 
-      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter, board)) end) =~
+      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter, board)) end) =~
         "Invalid input, please input a number between 1 and 9"
     end
 
@@ -65,7 +68,7 @@ defmodule TicTacToeIntegrationTest do
         7 => "O", 8 => "O", 9 => "X"
       }
 
-      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter, board)) end) =~
+      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter, board)) end) =~
         "No player has won, tie!\n"
     end
 
@@ -78,7 +81,7 @@ defmodule TicTacToeIntegrationTest do
         7 => :empty, 8 => :empty, 9 => :empty
       }
 
-      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLine, CommandLineFormatter, board)) end) =~
+      assert capture_io(user_input, fn -> IO.write(TicTacToe.start(CommandLineCommunicator, CommandLineFormatter, board)) end) =~
         """
         1 | 2 | O
         --|---|--

--- a/test/mocks/communicator_mock.ex
+++ b/test/mocks/communicator_mock.ex
@@ -5,6 +5,7 @@ defmodule CommunicatorMock do
   """
   use GenServer
 
+  alias Communication.CommunicationBehaviour
   @behaviour CommunicationBehaviour
 
   @impl true

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -1,6 +1,8 @@
 defmodule TicTacToeTest do
   use ExUnit.Case
 
+  alias Communication.CommandLine.CommandLineFormatter
+
   describe "start/1" do
     test "displays welcome message and board when start is first called" do
       user_input = ["1"]


### PR DESCRIPTION
Move the modules related to communication (right now only command line related).
Move the command line formatter into a command line directory nested inside
the communication directory as it is command line specific, not specific
to general communication. Use alias to allow for easy calls to the functions
even with the new naming convention.